### PR TITLE
Update to 1.61beta

### DIFF
--- a/com.snes9x.Snes9x.appdata.xml
+++ b/com.snes9x.Snes9x.appdata.xml
@@ -25,6 +25,7 @@
   <url type="homepage">http://snes9x.com</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2022-02-02" version="1.61beta"/>
     <release date="2019-04-25" version="1.60"/>
     <release date="2019-02-28" version="1.59.2"/>
     <release date="2019-02-27" version="1.59.0"/>

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -6,6 +6,10 @@
     "command": "snes9x-gtk",
     "rename-desktop-file": "snes9x-gtk.desktop",
     "rename-icon": "snes9x",
+    "cleanup": [
+        "/include",
+        "/lib/*.a"
+    ],
     "finish-args": [
         "--device=all",
         "--share=ipc",
@@ -18,6 +22,9 @@
         {
             "name": "mm-common",
             "buildsystem": "meson",
+            "cleanup": [
+                "/bin"
+            ],
             "sources": [
                 {
                     "type": "archive",

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -2,35 +2,109 @@
     "app-id": "com.snes9x.Snes9x",
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "command": "snes9x-gtk",
     "rename-desktop-file": "snes9x-gtk.desktop",
     "rename-icon": "snes9x",
     "finish-args": [
         "--device=all",
-        "--socket=x11",
+        "--share=ipc",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         "--filesystem=home"
     ],
     "modules": [
         {
-            "name": "glslang",
-            "buildsystem": "cmake-ninja",
+            "name": "mm-common",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.4.tar.xz",
+                    "sha256": "e954c09b4309a7ef93e13b69260acdc5738c907477eb381b78bb1e414ee6dbd8"
+                }
+            ]
+        },
+        {
+            "name": "sigc++",
             "config-opts": [
-                "-DBUILD_SHARED_LIBS=ON",
-                "-DENABLE_HLSL=OFF"
-            ],
-            "cleanup": [
-                "/bin",
-                "/include",
-                "/lib/*.a"
+                "--disable-documentation"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/KhronosGroup/glslang/archive/7.9.2888.tar.gz",
-                    "sha256": "cb66779d0e6b5f07f0445bd58289a24e56e12693e71d75c8fae3db31ffacaf8c"
+                    "url": "https://download.gnome.org/sources/libsigc%2B%2B/2.10/libsigc%2B%2B-2.10.8.tar.xz",
+                    "sha256": "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a"
+                }
+            ]
+        },
+        {
+            "name": "cairomm",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://cairographics.org/releases/cairomm-1.14.3.tar.xz",
+                    "sha256": "0d37e067c5c4ca7808b7ceddabfe1932c5bd2a750ad64fb321e1213536297e78"
+                }
+            ]
+        },
+        {
+            "name": "glibmm",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-documentation=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.2.tar.xz",
+                    "sha256": "b2a4cd7b9ae987794cbb5a1becc10cecb65182b9bb841868625d6bbb123edb1d"
+                }
+            ]
+        },
+        {
+            "name": "pangomm",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-documentation=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.2.tar.xz",
+                    "sha256": "57442ab4dc043877bfe3839915731ab2d693fc6634a71614422fb530c9eaa6f4"
+                }
+            ]
+        },
+        {
+            "name": "atkmm",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-documentation=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.2.tar.xz",
+                    "sha256": "a0bb49765ceccc293ab2c6735ba100431807d384ffa14c2ebd30e07993fd2fa4"
+                }
+            ]
+        },
+        {
+            "name": "gtkmm",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-documentation=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.5.tar.xz",
+                    "sha256": "856333de86689f6a81c123f2db15d85db9addc438bc3574c36f15736aeae22e6"
                 }
             ]
         },
@@ -50,15 +124,9 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/snes9xgit/snes9x/archive/1.60.tar.gz",
-                    "sha256": "861c8c0ab1d302d9df51e5ac4717a0069b33614a3f22bf3ab17ebf3405e58722"
-                },
-                {
                     "type": "git",
-                    "url": "https://github.com/KhronosGroup/SPIRV-Cross.git",
-                    "dest": "shaders/SPIRV-Cross",
-                    "commit": "1458bae62ec67ea7d12c5a13b740e23ed4bb226c"
+                    "url": "https://github.com/snes9xgit/snes9x.git",
+                    "commit": "f1ac3dc6d3d0b7d591224ef544d66f6e56533698"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
snes9x hasn't had an official release in about 2 years, but they are still working on it. They've recently updated the assets for 1.61:
![image](https://user-images.githubusercontent.com/848146/153716666-c2f95c12-91b5-48ee-b97e-2716aaf800bc.png)
and they're talking about a 1.61 release: https://github.com/snes9xgit/snes9x/issues/732

People tend not to use packages when they see the last update was 2 years ago. Since it's in a stable state, I thought it would be good to update to "1.61beta" based on the latest git commit.

Some other notable changes in the flatpak:
* Updated runtime to 21.08
* Set wayland as the default display protocol, with x11 fallback (see https://docs.flatpak.org/en/latest/sandbox-permissions.html#standard-permissions)
* snes9x 1.61 depends on gtkmm, which is unfortunately absent from the runtime, so it needs to be compiled in (https://github.com/snes9xgit/snes9x/blob/f1ac3dc6d3d0b7d591224ef544d66f6e56533698/docs/changes.txt#L25-L26)
* The shaders are now brought in as a submodule during snes9x compile, so they don't need to be dealt with separately anymore (see https://github.com/snes9xgit/snes9x/blob/f1ac3dc6d3d0b7d591224ef544d66f6e56533698/docs/changes.txt#L24)