### PR TITLE
update to 1.61

### DIFF
--- a/com.snes9x.Snes9x.appdata.xml
+++ b/com.snes9x.Snes9x.appdata.xml
@@ -25,6 +25,7 @@
   <url type="homepage">http://snes9x.com</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2022-03-04" version="1.61"/>
     <release date="2022-02-02" version="1.61beta"/>
     <release date="2019-04-25" version="1.60"/>
     <release date="2019-02-28" version="1.59.2"/>

--- a/com.snes9x.Snes9x.appdata.xml
+++ b/com.snes9x.Snes9x.appdata.xml
@@ -25,7 +25,7 @@
   <url type="homepage">http://snes9x.com</url>
   <content_rating type="oars-1.1" />
   <releases>
-    <release date="2022-03-04" version="1.61"/>
+    <release date="2022-03-04" version="1.61final"/>
     <release date="2022-02-02" version="1.61beta"/>
     <release date="2019-04-25" version="1.60"/>
     <release date="2019-02-28" version="1.59.2"/>

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -133,7 +133,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/snes9xgit/snes9x.git",
-                    "commit": "f1ac3dc6d3d0b7d591224ef544d66f6e56533698"
+                    "tag": "1.61",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^(.*)$",
+                        "is-main-source": true
+                    }
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Update to 1.61, which was released today, and setup external data checker to automatically create PRs for new versions