### PR TITLE
Update to newer version of Snes9x

### DIFF
--- a/com.snes9x.Snes9x.appdata.xml
+++ b/com.snes9x.Snes9x.appdata.xml
@@ -10,12 +10,15 @@
   <screenshots>
     <screenshot type="default">
       <image>http://www.snes9x.com/images/mrpg2.gif</image>
+      <caption>An image of the emulator running mario rpg</caption>
     </screenshot>
     <screenshot>
       <image>http://www.snes9x.com/images/mrpg1.gif</image>
+      <caption>An image of the emulator running mario rpg</caption>
     </screenshot>
     <screenshot>
       <image>http://www.snes9x.com/images/mariokart1.gif</image>
+      <caption>An image of the emulator running mario kart</caption>
     </screenshot>
   </screenshots>
   <metadata_license>CC0-1.0</metadata_license>
@@ -23,8 +26,9 @@
   <developer_name>Snes9x</developer_name>
   <translation type="gettext">snes9x-gtk</translation>
   <url type="homepage">http://snes9x.com</url>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2024-07-06" version="1.63"/>
     <release date="2022-03-04" version="1.62.3"/>
     <release date="2022-03-04" version="1.61final"/>
     <release date="2022-02-02" version="1.61beta"/>

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -63,7 +63,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.cairographics.org/releases/cairomm-1.14.5.tar.xz",
+                    "url": "https://cairographics.org/releases/cairomm-1.14.5.tar.xz",
                     "sha256": "70136203540c884e89ce1c9edfb6369b9953937f6cd596d97c78c9758a5d48db"
                 }
             ]

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -63,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://cairographics.org/releases/cairomm-1.18.0.tar.xz",
-                    "sha256": "b81255394e3ea8e8aa887276d22afa8985fc8daef60692eb2407d23049f03cfb"
+                    "url": "https://www.cairographics.org/releases/cairomm-1.14.5.tar.xz",
+                    "sha256": "70136203540c884e89ce1c9edfb6369b9953937f6cd596d97c78c9758a5d48db"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -91,8 +91,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.2.tar.xz",
-                    "sha256": "57442ab4dc043877bfe3839915731ab2d693fc6634a71614422fb530c9eaa6f4"
+                    "url": "https://download.gnome.org/sources/pangomm/2.54/pangomm-2.54.0.tar.xz",
+                    "sha256": "4a5b1fd1b7c47a1af45277ea82b5abeaca8e08fb10a27daa6394cf88d74e7acf"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -37,6 +37,19 @@
             "sources": [
                 {
                     "type": "archive",
+                    "url": "https://download.gnome.org/sources/libsigc%2B%2B/2.12/libsigc%2B%2B-2.12.1.tar.xz",
+                    "sha256": "a9dbee323351d109b7aee074a9cb89ca3e7bcf8ad8edef1851f4cf359bd50843"
+                }
+            ]
+        },
+        {
+            "name": "sigc++",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
                     "url": "https://download.gnome.org/sources/libsigc%2B%2B/3.6/libsigc%2B%2B-3.6.0.tar.xz",
                     "sha256": "c3d23b37dfd6e39f2e09f091b77b1541fbfa17c4f0b6bf5c89baef7229080e17"
                 }

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -77,8 +77,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.74/glibmm-2.74.1.tar.xz",
-                    "sha256": "1b78fb9d282a76b322866d5e2eeff288a25dec9c9464d85cd34969cd40cc1999"
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.7.tar.xz",
+                    "sha256": "fe02c1e5f5825940d82b56b6ec31a12c06c05c1583cfe62f934d0763e1e542b3"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -2,7 +2,7 @@
     "app-id": "com.snes9x.Snes9x",
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "command": "snes9x-gtk",
     "rename-desktop-file": "snes9x-gtk.desktop",
     "rename-icon": "snes9x",
@@ -24,8 +24,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.4.tar.xz",
-                    "sha256": "e954c09b4309a7ef93e13b69260acdc5738c907477eb381b78bb1e414ee6dbd8"
+                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.6.tar.xz",
+                    "sha256": "b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7"
                 }
             ]
         },
@@ -37,8 +37,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsigc%2B%2B/2.10/libsigc%2B%2B-2.10.8.tar.xz",
-                    "sha256": "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a"
+                    "url": "https://download.gnome.org/sources/libsigc%2B%2B/2.12/libsigc%2B%2B-2.12.1.tar.xz",
+                    "sha256": "a9dbee323351d109b7aee074a9cb89ca3e7bcf8ad8edef1851f4cf359bd50843"
                 }
             ]
         },
@@ -64,8 +64,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.2.tar.xz",
-                    "sha256": "b2a4cd7b9ae987794cbb5a1becc10cecb65182b9bb841868625d6bbb123edb1d"
+                    "url": "https://download.gnome.org/sources/glibmm/2.78/glibmm-2.78.1.tar.xz",
+                    "sha256": "f473f2975d26c3409e112ed11ed36406fb3843fa975df575c22d4cb843085f61"
                 }
             ]
         },
@@ -106,8 +106,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.5.tar.xz",
-                    "sha256": "856333de86689f6a81c123f2db15d85db9addc438bc3574c36f15736aeae22e6"
+                    "url": "https://download.gnome.org/sources/gtkmm/3.97/gtkmm-3.97.1.tar.xz",
+                    "sha256": "8faf90e61a423423afd7d4d70517666d6a09c17de490506e866c210c6a4a1283"
                 }
             ]
         },
@@ -133,8 +133,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://zlib.net/zlib-1.2.13.tar.xz",
-                    "sha256": "d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98"
+                    "url": "https://zlib.net/zlib-1.3.1.tar.xz",
+                    "sha256": "38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32"
                 },
                 {
                     "type": "script",
@@ -160,7 +160,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/snes9xgit/snes9x.git",
-                    "tag": "1.62.3",
+                    "tag": "1.63",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^(.*)$",

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -119,8 +119,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gtkmm/3.97/gtkmm-3.97.1.tar.xz",
-                    "sha256": "8faf90e61a423423afd7d4d70517666d6a09c17de490506e866c210c6a4a1283"
+                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.9.tar.xz",
+                    "sha256": "30d5bfe404571ce566a8e938c8bac17576420eb508f1e257837da63f14ad44ce"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -91,8 +91,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/pangomm/2.54/pangomm-2.54.0.tar.xz",
-                    "sha256": "4a5b1fd1b7c47a1af45277ea82b5abeaca8e08fb10a27daa6394cf88d74e7acf"
+                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.2.tar.xz",
+                    "sha256": "57442ab4dc043877bfe3839915731ab2d693fc6634a71614422fb530c9eaa6f4"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -37,8 +37,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsigc%2B%2B/2.12/libsigc%2B%2B-2.12.1.tar.xz",
-                    "sha256": "a9dbee323351d109b7aee074a9cb89ca3e7bcf8ad8edef1851f4cf359bd50843"
+                    "url": "https://download.gnome.org/sources/libsigc%2B%2B/3.6/libsigc%2B%2B-3.6.0.tar.xz",
+                    "sha256": "c3d23b37dfd6e39f2e09f091b77b1541fbfa17c4f0b6bf5c89baef7229080e17"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -43,19 +43,6 @@
             ]
         },
         {
-            "name": "sigc++",
-            "config-opts": [
-                "--disable-documentation"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsigc%2B%2B/3.6/libsigc%2B%2B-3.6.0.tar.xz",
-                    "sha256": "c3d23b37dfd6e39f2e09f091b77b1541fbfa17c4f0b6bf5c89baef7229080e17"
-                }
-            ]
-        },
-        {
             "name": "cairomm",
             "config-opts": [
                 "--disable-documentation"

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -63,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://cairographics.org/releases/cairomm-1.14.3.tar.xz",
-                    "sha256": "0d37e067c5c4ca7808b7ceddabfe1932c5bd2a750ad64fb321e1213536297e78"
+                    "url": "https://cairographics.org/releases/cairomm-1.18.0.tar.xz",
+                    "sha256": "b81255394e3ea8e8aa887276d22afa8985fc8daef60692eb2407d23049f03cfb"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -77,8 +77,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.78/glibmm-2.78.1.tar.xz",
-                    "sha256": "f473f2975d26c3409e112ed11ed36406fb3843fa975df575c22d4cb843085f61"
+                    "url": "https://download.gnome.org/sources/glibmm/2.74/glibmm-2.74.1.tar.xz",
+                    "sha256": "1b78fb9d282a76b322866d5e2eeff288a25dec9c9464d85cd34969cd40cc1999"
                 }
             ]
         },

--- a/com.snes9x.Snes9x.json
+++ b/com.snes9x.Snes9x.json
@@ -2,7 +2,7 @@
     "app-id": "com.snes9x.Snes9x",
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "command": "snes9x-gtk",
     "rename-desktop-file": "snes9x-gtk.desktop",
     "rename-icon": "snes9x",


### PR DESCRIPTION
Update to newer version of Snes9x, while also updating most of the dependencies and the platform to 23.08